### PR TITLE
Support build for arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,22 @@ $ cargo build
 ```bash
 $ docker build -f dockerfile-plus/Dockerfile .
 ```
+
+### Creating multi-arch build
+- Enable Experiment in docker config. Add {"experimental": true} to docker daemon.json
+- Setup BuildKit local build container
+```
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker buildx create --name multiarch --driver docker-container --use
+docker buildx inspect --bootstrap
+```
+- Run following to start multi-arch build
+```
+docker buildx build \                                                                   
+--platform linux/arm64/v8,linux/amd64 \
+--tag edrevo/dockerfile-plus:latest \
+-f dockerfile-plus/Dockerfile \
+--load ## or --push to push DockerHub \ 
+.
+```
+

--- a/dockerfile-plus/Dockerfile
+++ b/dockerfile-plus/Dockerfile
@@ -1,4 +1,5 @@
 # syntax = docker/dockerfile:1.2.1
+
 FROM rust:latest as builder
 USER root
 
@@ -12,7 +13,7 @@ RUN rustup target add "$(uname -m)-unknown-linux-musl"
 RUN --mount=type=cache,target=/rust-src/target \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cargo/registry \
-    cargo build --release --target "$(uname -m)-unknown-linux-musl" -p dockerfile-plus --verbose
+    cargo build --release --target "$(uname -m)-unknown-linux-musl" -p dockerfile-plus
 
 RUN --mount=type=cache,target=/rust-src/target \
     cp "/rust-src/target/$(uname -m)-unknown-linux-musl/release/dockerfile-plus" /usr/local/bin/dockerfile-plus

--- a/dockerfile-plus/Dockerfile
+++ b/dockerfile-plus/Dockerfile
@@ -1,18 +1,21 @@
 # syntax = docker/dockerfile:1.2.1
-
-FROM clux/muslrust:stable as builder
+FROM rust:latest as builder
 USER root
 
 WORKDIR /rust-src
 COPY . /rust-src
 
+RUN apt update && apt upgrade -y && apt install -y gcc-x86-64-linux-gnu gcc-aarch64-linux-gnu
+
+RUN rustup target add "$(uname -m)-unknown-linux-musl"
+
 RUN --mount=type=cache,target=/rust-src/target \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cargo/registry \
-    ["cargo", "build", "--release", "--target", "x86_64-unknown-linux-musl", "-p", "dockerfile-plus"]
+    cargo build --release --target "$(uname -m)-unknown-linux-musl" -p dockerfile-plus --verbose
 
 RUN --mount=type=cache,target=/rust-src/target \
-    ["cp", "/rust-src/target/x86_64-unknown-linux-musl/release/dockerfile-plus", "/usr/local/bin/dockerfile-plus"]
+    cp "/rust-src/target/$(uname -m)-unknown-linux-musl/release/dockerfile-plus" /usr/local/bin/dockerfile-plus
 
 FROM docker/dockerfile:1.2.1
 COPY --from=builder /usr/local/bin/dockerfile-plus /usr/local/bin/dockerfile-plus


### PR DESCRIPTION
Enable multi-arch build in docker and support build for both amd64 and arm64v8 (potentially other arch).